### PR TITLE
feat(kql): add sort, fields, time filters and fix special chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,27 @@ es-cli kql logs 'response_time:>1000'
 
 # Limit results
 es-cli kql logs 'status:error' -n 50
+
+# Sort by field (prefix with - for desc, + for asc, default is desc)
+es-cli kql logs 'status:error' --sort '@timestamp'
+es-cli kql logs 'status:error' --sort='-@timestamp'  # descending (most recent first)
+es-cli kql logs 'status:error' --sort='+@timestamp'  # ascending (oldest first)
+
+# Select specific fields (reduces output size)
+es-cli kql logs 'status:error' --fields '@timestamp,message,level'
+
+# Time filters
+es-cli kql logs 'status:error' --since 1h              # Last hour
+es-cli kql logs 'status:error' --since 30m             # Last 30 minutes
+es-cli kql logs 'status:error' --since 7d              # Last 7 days
+es-cli kql logs 'status:error' --from '2024-01-01T00:00:00Z' --to '2024-01-02T00:00:00Z'
+
+# Combine options
+es-cli kql logs 'status:error' --since 1h --sort '@timestamp' --fields '@timestamp,message' -n 100
+
+# Search with special characters (e.g., paths with /)
+# Uses simple_query_string internally, so special chars work without escaping
+es-cli kql audit 'owner/repo-name'
 ```
 
 ## License

--- a/src/commands/kql.rs
+++ b/src/commands/kql.rs
@@ -2,21 +2,82 @@ use crate::client::EsClient;
 use crate::format::format_output;
 use serde_json::json;
 
-pub async fn run(index: &str, query: &str, size: usize, human: bool) -> Result<(), String> {
+/// Options for KQL queries
+pub struct KqlOptions<'a> {
+    pub index: &'a str,
+    pub query: &'a str,
+    pub size: usize,
+    pub sort: Option<&'a str>,
+    pub fields: Option<&'a str>,
+    pub since: Option<&'a str>,
+    pub from: Option<&'a str>,
+    pub to: Option<&'a str>,
+    pub timestamp_field: &'a str,
+}
+
+pub async fn run(opts: KqlOptions<'_>, human: bool) -> Result<(), String> {
     let client = EsClient::new()?;
-    let path = format!("/{}/_search", index);
+    let path = format!("/{}/_search", opts.index);
 
-    let body = json!({
-        "query": {
-            "query_string": {
-                "query": query
+    // Build the query - use simple_query_string to avoid escaping issues with special chars like /
+    let query_clause = json!({
+        "simple_query_string": {
+            "query": opts.query,
+            "default_operator": "AND"
+        }
+    });
+
+    // Add time range filter if any time options are specified
+    let has_time_filter = opts.since.is_some() || opts.from.is_some() || opts.to.is_some();
+
+    let final_query = if has_time_filter {
+        let mut range = json!({});
+
+        if let Some(since) = opts.since {
+            range[opts.timestamp_field]["gte"] = json!(format!("now-{}", since));
+        }
+        if let Some(from) = opts.from {
+            range[opts.timestamp_field]["gte"] = json!(from);
+        }
+        if let Some(to) = opts.to {
+            range[opts.timestamp_field]["lte"] = json!(to);
+        }
+
+        json!({
+            "bool": {
+                "must": [query_clause],
+                "filter": [{ "range": range }]
             }
-        },
-        "size": size
-    })
-    .to_string();
+        })
+    } else {
+        query_clause
+    };
 
-    let response = client.post(&path, &body).await?;
+    // Build the request body
+    let mut body = json!({
+        "query": final_query,
+        "size": opts.size
+    });
+
+    // Add sort if specified
+    if let Some(sort) = opts.sort {
+        let (field, order) = if let Some(stripped) = sort.strip_prefix('-') {
+            (stripped, "desc")
+        } else if let Some(stripped) = sort.strip_prefix('+') {
+            (stripped, "asc")
+        } else {
+            (sort, "desc") // default to desc for most common use case (recent first)
+        };
+        body["sort"] = json!([{ field: order }]);
+    }
+
+    // Add _source filtering if fields specified
+    if let Some(fields) = opts.fields {
+        let field_list: Vec<&str> = fields.split(',').map(|s| s.trim()).collect();
+        body["_source"] = json!(field_list);
+    }
+
+    let response = client.post(&path, &body.to_string()).await?;
 
     if !response.status().is_success() {
         return Err(format!(

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -56,26 +56,22 @@ fn format_stats_human(json: &str) -> String {
         output.push_str(&format!(
             "{:<20} {}\n",
             "Min:",
-            min.map(format_number)
-                .unwrap_or_else(|| "-".to_string())
+            min.map(format_number).unwrap_or_else(|| "-".to_string())
         ));
         output.push_str(&format!(
             "{:<20} {}\n",
             "Max:",
-            max.map(format_number)
-                .unwrap_or_else(|| "-".to_string())
+            max.map(format_number).unwrap_or_else(|| "-".to_string())
         ));
         output.push_str(&format!(
             "{:<20} {}\n",
             "Average:",
-            avg.map(format_number)
-                .unwrap_or_else(|| "-".to_string())
+            avg.map(format_number).unwrap_or_else(|| "-".to_string())
         ));
         output.push_str(&format!(
             "{:<20} {}\n",
             "Sum:",
-            sum.map(format_number)
-                .unwrap_or_else(|| "-".to_string())
+            sum.map(format_number).unwrap_or_else(|| "-".to_string())
         ));
         output.push_str(&format!(
             "{:<20} {}\n",

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,32 @@ enum Commands {
         /// Number of results to return
         #[arg(short = 'n', long, default_value = "10")]
         size: usize,
+
+        /// Sort by field (prefix with - for desc, + for asc; default desc)
+        /// Example: -@timestamp, +status
+        #[arg(short = 's', long)]
+        sort: Option<String>,
+
+        /// Fields to include in response (comma-separated)
+        /// Example: @timestamp,message,level
+        #[arg(short = 'f', long)]
+        fields: Option<String>,
+
+        /// Time filter: documents from last duration (e.g., "1h", "30m", "7d")
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Time filter: start time (RFC3339 or Elasticsearch format)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Time filter: end time (RFC3339 or Elasticsearch format)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Timestamp field name for time filters (default: @timestamp)
+        #[arg(long, default_value = "@timestamp")]
+        timestamp_field: String,
     },
 
     /// Show statistics for a numeric field (min, max, avg, sum, std_dev)
@@ -165,8 +191,29 @@ async fn main() {
         Commands::Get { index } => commands::get::run(&index, cli.human).await,
         Commands::Search { index, query } => commands::search::run(&index, &query, cli.human).await,
         Commands::Esql { query } => commands::esql::run(&query, cli.human).await,
-        Commands::Kql { index, query, size } => {
-            commands::kql::run(&index, &query, size, cli.human).await
+        Commands::Kql {
+            index,
+            query,
+            size,
+            sort,
+            fields,
+            since,
+            from,
+            to,
+            timestamp_field,
+        } => {
+            let opts = commands::kql::KqlOptions {
+                index: &index,
+                query: &query,
+                size,
+                sort: sort.as_deref(),
+                fields: fields.as_deref(),
+                since: since.as_deref(),
+                from: from.as_deref(),
+                to: to.as_deref(),
+                timestamp_field: &timestamp_field,
+            };
+            commands::kql::run(opts, cli.human).await
         }
         Commands::Stats { index, field } => commands::stats::run(&index, &field, cli.human).await,
         Commands::Tail { index, size } => commands::tail::run(&index, size, cli.human).await,


### PR DESCRIPTION
## Summary

Improves the `kql` command with additional options for sorting, field selection, and time filtering. Also fixes an issue with special characters like `/` in queries.

## Changes

- **Switch to `simple_query_string`**: Fixes lexical errors when queries contain special characters like `/` (e.g., `owner/repo-name`)
- **Add `--sort` option**: Sort results by field (prefix with `-` for desc, `+` for asc, default is desc)
- **Add `--fields` option**: Select specific fields to return (comma-separated), reduces output size
- **Add time filter options**:
  - `--since <duration>`: Filter documents from last duration (e.g., `1h`, `30m`, `7d`)
  - `--from <timestamp>`: Filter documents from start time
  - `--to <timestamp>`: Filter documents until end time
  - `--timestamp-field <field>`: Customize timestamp field (default: `@timestamp`)

## Examples

```bash
# Search with special characters (previously failed with query_string)
es-cli kql audit 'owner/repo-name'

# Sort by timestamp (most recent first)
es-cli kql logs 'status:error' --sort '@timestamp'

# Select specific fields
es-cli kql logs 'status:error' --fields '@timestamp,message,level'

# Time filters
es-cli kql logs 'status:error' --since 1h
es-cli kql logs 'status:error' --from '2024-01-01T00:00:00Z' --to '2024-01-02T00:00:00Z'

# Combine options
es-cli kql logs 'status:error' --since 1h --sort '@timestamp' --fields '@timestamp,message' -n 100
```

---

This PR was created with assistance from Claude Code.