### PR TITLE
feat: add intuitive command aliases for LLM discoverability

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ enum Commands {
     },
 
     /// List datastreams (GET /_data_stream)
+    #[command(alias = "data-streams")]
     Datastreams {
         /// Optional pattern to filter datastreams (supports wildcards, e.g., "*audit*")
         pattern: Option<String>,
@@ -69,9 +70,11 @@ enum Commands {
     },
 
     /// List all indices (GET /_cat/indices?format=json)
+    #[command(alias = "indices")]
     List,
 
     /// Get mapping for an index (GET /<index>/_mapping)
+    #[command(alias = "mapping")]
     Get {
         /// Index name or pattern (e.g., "my-index" or "logs-*")
         index: String,
@@ -95,7 +98,7 @@ enum Commands {
     },
 
     /// Search with KQL/Lucene query string syntax
-    #[command(name = "kql")]
+    #[command(name = "kql", alias = "query")]
     Kql {
         /// Index name or pattern to search
         index: String,
@@ -154,6 +157,7 @@ enum Commands {
     },
 
     /// Show top unique values for a field (terms aggregation)
+    #[command(alias = "top-values")]
     Values {
         /// Index name or pattern
         index: String,


### PR DESCRIPTION
## Summary

- Adds command aliases so that LLMs (like Claude) are more likely to guess the correct subcommand name
- All original command names are preserved — the new names are aliases only

| Command | New Alias |
|---------|-----------|
| `get` | `mapping` |
| `list` | `indices` |
| `kql` | `query` |
| `datastreams` | `data-streams` |
| `values` | `top-values` |

## Original prompt

> I tried using claude code with es-cli and it had assumed that some subcommands existed that do not exist. Can you suggest some new command names that claude is more likely to use to replace existing ones?

## Test plan

- [x] `cargo build` succeeds
- [x] Verify each alias resolves to the correct command (e.g. `es-cli mapping <index>` works like `es-cli get <index>`)
- [x] Verify original command names still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)