### PR TITLE
fix(kql): uppercase and/or/not so lowercase operators stop returning zero

### DIFF
--- a/src/commands/kql.rs
+++ b/src/commands/kql.rs
@@ -15,6 +15,59 @@ pub struct KqlOptions<'a> {
     pub timestamp_field: &'a str,
 }
 
+/// KQL accepts `and`/`or`/`not` in any case, but this command runs on
+/// `query_string`, whose Lucene syntax only treats them as operators in upper
+/// case. A lower-case `or` is parsed as a term to match instead, and since
+/// `default_operator` is AND it has to match for the query to return anything,
+/// so `a:1 or b:2` quietly returns zero hits rather than the union. Upper-case
+/// the operators on the way in. Anything inside double quotes is a phrase and
+/// is left alone, as is a token like `status:or` where the word is a value.
+fn uppercase_boolean_operators(query: &str) -> String {
+    let mut out = String::with_capacity(query.len());
+    let mut word = String::new();
+    let mut in_quotes = false;
+    let mut escaped = false;
+
+    fn flush(word: &mut String, out: &mut String) {
+        let is_operator = ["and", "or", "not"]
+            .iter()
+            .any(|operator| word.eq_ignore_ascii_case(operator));
+        if is_operator {
+            out.push_str(&word.to_ascii_uppercase());
+        } else {
+            out.push_str(word);
+        }
+        word.clear();
+    }
+
+    for character in query.chars() {
+        if escaped {
+            word.push(character);
+            escaped = false;
+            continue;
+        }
+        match character {
+            '\\' => {
+                word.push(character);
+                escaped = true;
+            }
+            '"' => {
+                in_quotes = !in_quotes;
+                word.push(character);
+            }
+            _ if in_quotes => word.push(character),
+            // The delimiters that can end a bare operator token in Lucene.
+            ' ' | '\t' | '\n' | '(' | ')' => {
+                flush(&mut word, &mut out);
+                out.push(character);
+            }
+            _ => word.push(character),
+        }
+    }
+    flush(&mut word, &mut out);
+    out
+}
+
 pub async fn run(opts: KqlOptions<'_>, human: bool) -> Result<(), String> {
     let client = EsClient::new()?;
     let path = format!("/{}/_search", opts.index);
@@ -25,7 +78,7 @@ pub async fn run(opts: KqlOptions<'_>, human: bool) -> Result<(), String> {
     // wildcard expansion on analyzed fields.
     let query_clause = json!({
         "query_string": {
-            "query": opts.query,
+            "query": uppercase_boolean_operators(opts.query),
             "default_operator": "AND",
             "lenient": true,
             "analyze_wildcard": true
@@ -95,4 +148,66 @@ pub async fn run(opts: KqlOptions<'_>, human: bool) -> Result<(), String> {
     let body = response.text().await.map_err(|e| e.to_string())?;
     println!("{}", format_output(&body, human));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::uppercase_boolean_operators;
+
+    #[test]
+    fn uppercases_bare_operators() {
+        assert_eq!(
+            uppercase_boolean_operators("actor.type:USER or origin:ADMIN_CONSOLE"),
+            "actor.type:USER OR origin:ADMIN_CONSOLE"
+        );
+        assert_eq!(
+            uppercase_boolean_operators("a:1 and b:2 not c:3"),
+            "a:1 AND b:2 NOT c:3"
+        );
+        assert_eq!(uppercase_boolean_operators("a:1 And b:2"), "a:1 AND b:2");
+    }
+
+    #[test]
+    fn leaves_already_valid_queries_untouched() {
+        for query in [
+            "actor.type:USER OR origin:NODE",
+            "json.objectRef.subresource:exec",
+            "",
+        ] {
+            assert_eq!(uppercase_boolean_operators(query), query);
+        }
+    }
+
+    #[test]
+    fn parentheses_delimit_operators() {
+        assert_eq!(
+            uppercase_boolean_operators("(a:1 or b:2) and c:3"),
+            "(a:1 OR b:2) AND c:3"
+        );
+    }
+
+    #[test]
+    fn spares_operators_that_are_not_operators() {
+        // A phrase is searched literally, so its words stay as the user typed them.
+        assert_eq!(
+            uppercase_boolean_operators("message:\"cat and mouse\""),
+            "message:\"cat and mouse\""
+        );
+        // Same word as a field value, or as part of one.
+        assert_eq!(uppercase_boolean_operators("status:or"), "status:or");
+        assert_eq!(uppercase_boolean_operators("region:nord"), "region:nord");
+        assert_eq!(
+            uppercase_boolean_operators("name:or_tool and b:2"),
+            "name:or_tool AND b:2"
+        );
+    }
+
+    #[test]
+    fn preserves_escapes_and_whitespace() {
+        assert_eq!(
+            uppercase_boolean_operators("path:a\\ or\\ b or c:1"),
+            "path:a\\ or\\ b OR c:1"
+        );
+        assert_eq!(uppercase_boolean_operators("a:1\tor\nb:2"), "a:1\tOR\nb:2");
+    }
 }


### PR DESCRIPTION
## The bug

`kql` builds a `query_string` query, whose Lucene syntax only recognises `and`, `or` and `not` as boolean operators **in upper case**. Written in lower case, `or` is parsed as a plain term to match, and since the command sets `default_operator: "AND"`, that term has to match for the query to return anything. It never does, so the query comes back with zero hits instead of the union.

There is no error and no warning. An empty result is indistinguishable from a genuinely quiet window, which is the dangerous part: this silently turns a real match into "nothing happened".

Measured on a live cluster, same 24h window:

```
es-cli kql ds-tailscale-audit 'actor.type:USER'                          ->  5
es-cli kql ds-tailscale-audit 'origin:NODE'                              -> 53
es-cli kql ds-tailscale-audit 'actor.type:USER or origin:NODE'           ->  0   # wrong
es-cli kql ds-tailscale-audit 'actor.type:USER and origin:NODE'          ->  0   # wrong
es-cli kql ds-tailscale-audit 'actor.type:USER OR origin:ADMIN_CONSOLE'  ->  5   # correct
```

It is neither index-specific nor field-specific, the same pair fails on `ds-audit-*`.

This bit for real: an automated detector's "was there any human action in this window" query was a lowercase multi-clause KQL. It read 0, concluded no human touched the tailnet, and closed the window clean while five real user events sat in the index.

## The fix

Upper-case bare `and`/`or`/`not` before handing the query to Elasticsearch, rather than rejecting them. KQL proper accepts either case and the command is called `kql`, so accepting what a KQL user would type is the behaviour that matches the name.

The pass is quote-aware and leaves alone anything that is not a bare operator token:

- `message:"cat and mouse"` stays a literal phrase
- `status:or` and `name:or_tool` are values, untouched
- `path:a\ or\ b` keeps its escaped spaces
- already-upper-case queries are unchanged

Delimiters are whitespace and parentheses, so `(a:1 or b:2) and c:3` works.

## Verification

Five unit tests cover the cases above (the crate had no test module before, this adds one in `kql.rs`). Re-run against the live cluster after the change: the two queries that returned 0 now return 5, and every query that was already correct returns exactly what it did before.